### PR TITLE
Frame ID Issue

### DIFF
--- a/src/sf40c.cpp
+++ b/src/sf40c.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv) {
 		return 1;
 	}
 
-	// initScanRev(&scanRev, rosScanData, frameId);
+	initScanRev(&scanRev, rosScanData, frameId);
 	
 	if (driverScanStart(serial) != 0) {
 		RCLCPP_ERROR(node->get_logger(), "Failed to start scan");


### PR DESCRIPTION
sf40c.cpp never set the frameId parameter, resulting in empty frame_id in message.
Uncommenting the line fixes the issue. 